### PR TITLE
Fix HeadersAlreadySentException

### DIFF
--- a/src/actions/GlideAction.php
+++ b/src/actions/GlideAction.php
@@ -48,6 +48,7 @@ class GlideAction extends Action
         try {
             Yii::$app->getResponse()->format = Response::FORMAT_RAW;
             $this->getServer()->outputImage($path, Yii::$app->request->get());
+            exit;
         } catch (\Exception $e) {
             throw new NotSupportedException($e->getMessage());
         }

--- a/src/actions/GlideAction.php
+++ b/src/actions/GlideAction.php
@@ -48,7 +48,7 @@ class GlideAction extends Action
         try {
             Yii::$app->getResponse()->format = Response::FORMAT_RAW;
             $this->getServer()->outputImage($path, Yii::$app->request->get());
-            exit;
+            Yii::$app->end();
         } catch (\Exception $e) {
             throw new NotSupportedException($e->getMessage());
         }


### PR DESCRIPTION
Since Yii2 version `2.0.14` there is a new exception thrown if headers are already sent:
https://github.com/yiisoft/yii2/issues/15046

Since the `outputImage()` method in this library sends headers, this causes every request to generate an error. The only thing we risk with this PR is that `web/Response` events are not being triggered any more.

This will solve #19 

If you accept this PR, please bump `yii2-glide` version.