### PR TITLE
Fix a bug related to manipulators order.

### DIFF
--- a/src/components/Glide.php
+++ b/src/components/Glide.php
@@ -258,9 +258,9 @@ class Glide extends Component
             'driver' => extension_loaded('imagick') ? 'imagick' : 'gd'
         ]);
         $manipulators = [
-            new Size($this->maxImageSize),
             new Orientation(),
             new Crop(),
+            new Size($this->maxImageSize),
             new Brightness(),
             new Contrast(),
             new Gamma(),


### PR DESCRIPTION
If you request an image with size width 300, height 240 and it is first resized, later rotated, you get an image wide 240px and high 300px. The order of manipulators is important and is stated differently in the docs of `thephpleague/glide`.